### PR TITLE
Fixes #347 (param is assumed to be array when it contains 'length' property)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -95,7 +95,7 @@ export function each(obj, iterator) {
 
     var i, key;
 
-    if (obj && typeof obj.length == 'number') {
+    if (isArray(obj)) {
         for (i = 0; i < obj.length; i++) {
             iterator.call(obj[i], obj[i], i);
         }

--- a/test/url.js
+++ b/test/url.js
@@ -30,4 +30,15 @@ describe('Vue.url', function () {
 
     });
 
+    it('url with params', function () {
+
+        expect(Vue.url('url', {})).toBe('url');
+        expect(Vue.url('url', {foo: 'bar'})).toBe('url?foo=bar');
+        expect(Vue.url('url', {foo: 'bar', b: 10})).toBe('url?foo=bar&b=10');
+
+        // Bug #347: Would be 'url?0=undefined&1=undefined'
+        expect(Vue.url('url', {length:2})).toBe('url?length=2');
+
+    });
+
 });


### PR DESCRIPTION
Contains fix for $347 including testcase.
