### PR TITLE
Support Vue.js 2 SSR Fixes #350 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "rollup-plugin-babel": "^2.6.1",
     "uglify-js": "^2.7.3",
     "vue": "^1.0.26",
-    "webpack": "2.1.0-beta.21"
+    "webpack": "2.1.0-beta.21",
+    "xhr2": "latest"
   }
 }

--- a/src/http/client/jsonp.js
+++ b/src/http/client/jsonp.js
@@ -4,6 +4,8 @@
 
 import Promise from '../../promise';
 
+const inBrowser = typeof window !== 'undefined';
+
 export default function (request) {
     return new Promise((resolve) => {
 
@@ -21,23 +23,27 @@ export default function (request) {
 
             resolve(request.respondWith(body, {status}));
 
-            delete window[callback];
-            document.body.removeChild(script);
+            if (inBrowser) {
+                delete window[callback];
+                document.body.removeChild(script);
+            }
         };
 
         request.params[name] = callback;
 
-        window[callback] = (result) => {
-            body = JSON.stringify(result);
-        };
+        if (inBrowser) {
+            window[callback] = (result) => {
+                body = JSON.stringify(result);
+            };
 
-        script = document.createElement('script');
-        script.src = request.getUrl();
-        script.type = 'text/javascript';
-        script.async = true;
-        script.onload = handler;
-        script.onerror = handler;
+            script = document.createElement('script');
+            script.src = request.getUrl();
+            script.type = 'text/javascript';
+            script.async = true;
+            script.onload = handler;
+            script.onerror = handler;
 
-        document.body.appendChild(script);
+            document.body.appendChild(script);
+        }
     });
 }

--- a/src/http/client/xhr.js
+++ b/src/http/client/xhr.js
@@ -5,6 +5,9 @@
 import Promise from '../../promise';
 import { each, trim } from '../../util';
 
+const inBrowser = typeof window !== 'undefined';
+const XMLHttpRequest = inBrowser ? window.XMLHttpRequest : require('xhr2');
+
 export default function (request) {
     return new Promise((resolve) => {
 

--- a/src/http/interceptor/cors.js
+++ b/src/http/interceptor/cors.js
@@ -6,8 +6,9 @@ import Url from '../../url/index';
 import xdrClient from '../client/xdr';
 import { isBoolean } from '../../util';
 
-const ORIGIN_URL = Url.parse(location.href);
-const SUPPORTS_CORS = 'withCredentials' in new XMLHttpRequest();
+const inBrowser = typeof window !== 'undefined';
+const ORIGIN_URL =  Url.parse(inBrowser ? location.href : '');
+const SUPPORTS_CORS = inBrowser ? 'withCredentials' in new XMLHttpRequest() : true;
 
 export default function (request, next) {
 

--- a/src/promise.js
+++ b/src/promise.js
@@ -2,10 +2,12 @@
  * Promise adapter.
  */
 
-import PromiseLib from './lib/promise';
+import Promise from './lib/promise';
 
-if (typeof Promise === 'undefined') {
-    window.Promise = PromiseLib;
+const inBrowser = typeof window !== 'undefined';
+
+if (inBrowser && typeof window.Promise === 'undefined') {
+    window.Promise = Promise;
 }
 
 export default function PromiseObj(executor, context) {

--- a/src/url/index.js
+++ b/src/url/index.js
@@ -2,8 +2,18 @@
  * Service for URL templating.
  */
 
-const ie = document.documentMode;
-const el = document.createElement('a');
+const inBrowser = typeof window !== 'undefined';
+const ie = inBrowser ? document.documentMode : 11;
+const el = inBrowser ? document.createElement('a') : {
+    href: '',
+    protocol: '',
+    port: '',
+    host: '',
+    hostname: '',
+    pathname: '',
+    search: '',
+    hash: '',
+};
 
 import root from './root';
 import query from './query';


### PR DESCRIPTION
This PR adds Vue2 SSR support to `vue-resource` using [XMLHttpRequest emulator](https://www.npmjs.com/package/xhr2) also every usage of `window` , `location` and `document` is checked for browser support.
