### PR TITLE
Fix possible error of `each` method

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -101,7 +101,7 @@ export function each(obj, iterator) {
         }
     } else if (isObject(obj)) {
         for (key in obj) {
-            if (obj.hasOwnProperty(key)) {
+            if ({}.hasOwnProperty.call(obj, key)) {
                 iterator.call(obj[key], obj[key], key);
             }
         }


### PR DESCRIPTION
When `each` method is called, object not extends `Object.prototype`'s `hasOwnProperty` property could possibly cause an error:

``` js
const obj = Object.create(null)
obj.a = 1
const iterator = x => x

each(obj, iterator)
// Uncaught TypeError: obj.hasOwnProperty is not a function(…)
```

This PR use `{}.hasOwnProperty.call` instead.
