### PR TITLE
Added note for the root option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,8 @@ Vue.http.options.root = '/root';
 Vue.http.headers.common['Authorization'] = 'Basic YXBpOnBhc3N3b3Jk';
 ```
 
+Note that for the root option to work, the path of the request may not start with a `/`. This will use this the root option: `Vue.$http.get('user')` while this will not: `Vue.$http.get('/user')`.
+
 Set default values inside your Vue component options.
 
 ```js


### PR DESCRIPTION
The root option only works if the path of a request does not start with a forward slash. This was not documented and is not obvious.

It would probably also make sense to document each option that is available for configuration.

I also just filed [this bug](https://github.com/pagekit/vue-resource/issues/487) that setting configuration options inside the Vue component options doesn't work. Don't know if it should be in the documentation or not.