### PR TITLE
Fixed too many args error message on resources

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -55,7 +55,7 @@ function opts(action, args) {
 
         default:
 
-            throw 'Expected up to 4 arguments [params, body], got ' + args.length + ' arguments';
+            throw 'Expected up to 2 arguments [params, body], got ' + args.length + ' arguments';
     }
 
     options.body = body;


### PR DESCRIPTION
Fixed error message when more than 2 args where supplied when calling a resource.
The message stated that the resource expected up to **4** arguments, when it actually only allows up to 2.