### PR TITLE
Fix: timeout option with jsonp

### DIFF
--- a/src/http/client/jsonp.js
+++ b/src/http/client/jsonp.js
@@ -7,9 +7,14 @@ import Promise from '../../promise';
 export default function (request) {
     return new Promise((resolve) => {
 
-        var name = request.jsonp || 'callback', callback = '_jsonp' + Math.random().toString(36).substr(2), body = null, handler, script;
+        var name = request.jsonp || 'callback', callback = '_jsonp' + Math.random().toString(36).substr(2), body = null, handler, script, isHandled = false;
 
         handler = ({type}) => {
+            if (isHandled) {
+                return;
+            }
+
+            isHandled = true
 
             var status = 0;
 
@@ -27,8 +32,18 @@ export default function (request) {
 
         request.params[name] = callback;
 
+        request.abort = () => {
+            if (!isHandled) {
+                handler({});
+            }
+        }
+
         window[callback] = (result) => {
-            body = JSON.stringify(result);
+            try {
+                body = JSON.stringify(result);
+            } catch (e) {
+                body = null;
+            }
         };
 
         script = document.createElement('script');

--- a/src/http/response.js
+++ b/src/http/response.js
@@ -40,7 +40,13 @@ export default class Response {
     }
 
     json() {
-        return when(this.text(), text => JSON.parse(text));
+        return when(this.text(), text => {
+            try {
+                return JSON.parse(text);
+            } catch (e) {
+                return null;
+            }
+        });
     }
 
 }


### PR DESCRIPTION
When jsonp request with the option 'timeout', it may cause an error: 'Uncaught TypeError: request.abort is not a function'.

I fixed this by adding the request.abort for jsonp.