### PR TITLE
Allow responseType to be changed from options

### DIFF
--- a/src/http/client/xhr.js
+++ b/src/http/client/xhr.js
@@ -5,8 +5,6 @@
 import Promise from '../../promise';
 import { each, trim } from '../../util';
 
-const SUPPORTS_BLOB = typeof Blob !== 'undefined' && typeof FileReader !== 'undefined';
-
 export default function (request) {
     return new Promise(resolve => {
 
@@ -51,7 +49,7 @@ export default function (request) {
         }
 
         if ('responseType' in xhr) {
-            xhr.responseType = request.responseType || (SUPPORTS_BLOB ? 'blob' : '');
+            xhr.responseType = request.responseType || '';
         }
 
         request.headers.forEach((value, name) => {

--- a/src/http/client/xhr.js
+++ b/src/http/client/xhr.js
@@ -50,8 +50,8 @@ export default function (request) {
             request.headers.set('X-Requested-With', 'XMLHttpRequest');
         }
 
-        if ('responseType' in xhr && SUPPORTS_BLOB) {
-            xhr.responseType = 'blob';
+        if ('responseType' in xhr) {
+            xhr.responseType = request.responseType || (SUPPORTS_BLOB ? 'blob' : '');
         }
 
         request.headers.forEach((value, name) => {


### PR DESCRIPTION
Let people fix empty response in Chrome for CORS requests by allowing custom responseType to be defined in options.