### PR TITLE
jsonp添加设置charset选项

### DIFF
--- a/src/http/client/jsonp.js
+++ b/src/http/client/jsonp.js
@@ -47,6 +47,7 @@ export default function (request) {
         script.async = true;
         script.onload = handler;
         script.onerror = handler;
+        script.charset = request.jsonpCharset || '';
 
         document.body.appendChild(script);
     });


### PR DESCRIPTION
兼容只能提供gbk编码的服务端接口