### PR TITLE
:bug: Fixed root option trailing slash issue

### DIFF
--- a/src/url/root.js
+++ b/src/url/root.js
@@ -2,14 +2,14 @@
  * Root Prefix Transform.
  */
 
-import { isString } from '../util';
+import { isString, trimEnd } from '../util';
 
 export default function (options, next) {
 
     var url = next(options);
 
-    if (isString(options.root) && !url.match(/^(https?:)?\//)) {
-        url = options.root + '/' + url;
+    if (isString(options.root) && !/^(https?:)?\//.test(url)) {
+        url = trimEnd(options.root, '/') + '/' + url;
     }
 
     return url;

--- a/src/util.js
+++ b/src/util.js
@@ -33,6 +33,16 @@ export function trim(str) {
     return str ? str.replace(/^\s*|\s*$/g, '') : '';
 }
 
+export function trimEnd(string, chars) {
+    if (string && chars === undefined) {
+        return string.replace(/\s+$/, '');
+    }
+    if (!string || !chars) {
+        return string;
+    }
+    return string.replace(new RegExp(`[${chars}]+$`), '');
+}
+
 export function toLower(str) {
     return str ? str.toLowerCase() : '';
 }


### PR DESCRIPTION
By setting the root to `/` the urls would be transformed to `//url` which will break relative paths and make them absolute URLs unintentionally.

This commit contains trailing slash trimming for the root option, so that concatenating the `root+ '/' +url` would be safe.

- - -

Also checking regex for absolute paths w/ `test` is more performant than trying to get the `match`es.