### PR TITLE
fixed Issues #615 URL Query Params When Use Array Params

### DIFF
--- a/src/url/index.js
+++ b/src/url/index.js
@@ -121,7 +121,7 @@ function serialize(params, obj, scope) {
         hash = isObject(value) || isArray(value);
 
         if (scope) {
-            key = scope + '[' + (plain || hash ? key : '') + ']';
+            key = scope + (plain || hash ? '[' + key + ']' : '');
         }
 
         if (!scope && array) {


### PR DESCRIPTION
Origined:

URL?test[]=A&test[]=B

Fixed:

URL?test=A&test=B