### PR TITLE
Handle rejected promises

### DIFF
--- a/src/http/client/index.js
+++ b/src/http/client/index.js
@@ -16,7 +16,7 @@ export default function (context) {
     }
 
     function Client(request) {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
 
             function exec() {
 
@@ -44,7 +44,7 @@ export default function (context) {
                         });
                     });
 
-                    when(response, resolve);
+                    when(response, resolve, reject);
 
                     return;
                 }


### PR DESCRIPTION
vue-resource doesn't handle promise rejections and instead we get unhandled rejection errors which makes error handling harder. This patch just sends the rejection up the chain so that the error can be handled.

The added benefit is that `interceptors` now can return a rejected Promise which has been listed as an issue [here](https://github.com/pagekit/vue-resource/issues/377)