### PR TITLE
Avert stringify result when result is string yet

### DIFF
--- a/src/http/client/jsonp.js
+++ b/src/http/client/jsonp.js
@@ -28,7 +28,7 @@ export default function (request) {
         };
 
         window[callback] = result => {
-            body = JSON.stringify(result);
+            body = typeof result === 'string' ? result : JSON.stringify(result);
         };
 
         request.abort = () => {


### PR DESCRIPTION
When I use jsonp request, if api response result as below
```
callback('{"timestamp": 1499421237, "nonceStr": "kAi5na4ckNG3uv3xg9MVdP"}');
```
We must use `JSON.parse` twice, so I think it's necessary to add a judge with `body = typeof result === 'string' ? result : JSON.stringify(result)`

What do you think！