### PR TITLE
Enhancement on custom actions documentation

### DIFF
--- a/docs/resource.md
+++ b/docs/resource.md
@@ -68,3 +68,26 @@ delete: {method: 'DELETE'}
   });
 }
 ```
+
+**Note:** When passing only one single object (for POST, PUT and PATCH custom actions), it will defaults to body param. If you need set url params you will have to pass an empty object as second argument.
+
+```js
+{
+  var resource = this.$resource('someItem{/id}', {}, {
+    baz: {method: 'POST', url: 'someItem/baz{/id}'}
+  });
+
+  // POST someItem/baz
+  resource.baz({id: 1}).then(response => {
+    // success callback
+  }, response => {
+    // error callback
+  });
+
+  // POST someItem/baz/1
+  resource.baz({id: 1}, {}).then(response => {
+    // success callback
+  }, response => {
+    // error callback
+  });
+```


### PR DESCRIPTION
Added a note explaining the use of custom actions (POST, PUT, and PATCH) for when passing single object in.

Closes #556