### PR TITLE
interceptors return function with Promise.reject

### DIFF
--- a/src/http/client/index.js
+++ b/src/http/client/index.js
@@ -32,7 +32,7 @@ export default function (context) {
                         resHandlers.forEach(handler => {
                             response = when(response, response => {
                                 return handler.call(context, response) || response;
-                            }, reject);
+                            });
                         });
 
                         when(response, resolve, reject);


### PR DESCRIPTION
the reject  add to every response handler.
when interceptor next function params return a Promise.reject() the first response handler will catch it and run reject.
if the reject not throws new error  the next response handlers will still run resolve function with the return value of reject function