### PR TITLE
Fixed delete method forcing JSON content type

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -55,7 +55,7 @@ Http.headers = {
     put: JSON_CONTENT_TYPE,
     post: JSON_CONTENT_TYPE,
     patch: JSON_CONTENT_TYPE,
-    delete: JSON_CONTENT_TYPE,
+    delete: COMMON_HEADERS,
     common: COMMON_HEADERS,
     custom: {}
 };


### PR DESCRIPTION
I was having trouble using the DELETE method. It was forcing `Content-Type | text/html; charset=UTF-8`. This "crashed" my web framework as it was trying to parse JSON while there wasn't any content.

