### PR TITLE
Fix GET overload with config not typed

### DIFF
--- a/types/vue_resource.ts
+++ b/types/vue_resource.ts
@@ -38,8 +38,8 @@ export interface HttpOptions {
 }
 
 export interface $http {
-    (url: string, data?: any, options?: HttpOptions): PromiseLike<HttpResponse>;
     (url: string, options?: HttpOptions): PromiseLike<HttpResponse>;
+    (url: string, data?: any, options?: HttpOptions): PromiseLike<HttpResponse>;
 }
 
 export interface HttpInterceptor {


### PR DESCRIPTION
The http get params not getting properly typed because of the 2nd params on first overload is assigned with any

```typescript
Vue.http.get('something', { params: { foo: 'Foo' } }) // <-- the object is read as any
```

expected
```typescript
Vue.http.get('something', { params: { foo: 'Foo' } }) // <-- the object should have autocomplete config
```